### PR TITLE
Bugfix: Internal server error caused by incomplete formatting

### DIFF
--- a/app/views/versions/_overview.html.erb
+++ b/app/views/versions/_overview.html.erb
@@ -17,7 +17,7 @@
 <% end %>
 
 <% if version.issues_count > 0 %>
-  <%= progress_bar([version.closed_percent, version.completed_percent], width: '40em', legend: ('%0.0f%' % version.completed_percent)) %>
+  <%= progress_bar([version.closed_percent, version.completed_percent], width: '40em', legend: ('%0.0f%%' % version.completed_percent)) %>
   <p class="progress-info">
     <%= link_to(l(:label_x_issues, count: version.issues_count),
         version_issues_cpath(version, status_id: '*')) %>


### PR DESCRIPTION
On Redmine 3.4.4.stable with Ruby 2.5.1-p57 an incomplete format error
in this file causes Redmine to throw a 500 Internal Server Error when
attempting to view a project Roadmap.